### PR TITLE
FIX | Update Reference content type from array to string and adjust structure documentation, add title to references

### DIFF
--- a/internal/domain/dtos/case_dto.go
+++ b/internal/domain/dtos/case_dto.go
@@ -10,7 +10,8 @@ import (
 // Start of Selection
 type Reference struct {
 	ID      helpers.Nullable[string]   `json:"id" bson:"id"`
-	Content helpers.Nullable[[]string] `json:"content" bson:"content"`
+	Title   helpers.Nullable[string] `json:"title" bson:"title"`
+	Content helpers.Nullable[string] `json:"content" bson:"content"`
 }
 
 type MessageResponse struct {

--- a/internal/domain/models/case.go
+++ b/internal/domain/models/case.go
@@ -29,7 +29,8 @@ type Collaborators struct {
 
 type Reference struct {
 	ID      string   `json:"id" bson:"id"`
-	Content []string `json:"content" bson:"content"`
+	Title   string `json:"title" bson:"title"`
+	Content string `json:"content" bson:"content"`
 }
 
 type Message struct {

--- a/internal/domain/services/mappers/case_mapper.go
+++ b/internal/domain/services/mappers/case_mapper.go
@@ -256,6 +256,7 @@ func (s *CaseConversionServiceImpl) MessageToDTO(message models.Message) dtos.Me
 	for i, r := range message.References {
 		references[i] = dtos.Reference{
 			ID:      helpers.NewNullable(r.ID),
+			Title:  helpers.NewNullable(r.Title),
 			Content: helpers.NewNullable(r.Content),
 		}
 	}
@@ -308,6 +309,7 @@ func (s *CaseConversionServiceImpl) DTOToMessage(messageDTO dtos.MessageResponse
 		s.logger.Info(fmt.Sprintf("- Content: %v", r.Content.Value))
 		references = append(references, models.Reference{
 			ID:      r.ID.Value,
+			Title:   r.Title.Value,
 			Content: r.Content.Value,
 		})
 	}

--- a/structure.MD
+++ b/structure.MD
@@ -8,7 +8,9 @@ LEGAL_ASSISTANT (WORKSPACE)
 |   |   |   |-- errors.go
 |   |   |   `-- router.go
 |   |   `-- http
-|   |       `-- server.go
+|   |       |-- app.go
+|   |       |-- http_server.go
+|   |       |-- main.go
 |   |-- domain
 |   |   |-- daos
 |   |   |-- dtos


### PR DESCRIPTION
This pull request includes several changes to the `Reference` struct and updates to the `CaseConversionServiceImpl` methods in the `internal/domain` package, as well as modifications to the project structure in `structure.MD`.

### Changes to `Reference` struct:

* [`internal/domain/dtos/case_dto.go`](diffhunk://#diff-cecc3b036d2b30bfe9b447630308a1d9bd0895666f6f0cd2d252ca2cbc8a29d7L13-R14): Added `Title` field to the `Reference` struct and changed the type of `Content` from `helpers.Nullable[[]string]` to `helpers.Nullable[string]`.
* [`internal/domain/models/case.go`](diffhunk://#diff-ae3c2090c2d35e787483a2b85da0c49b439a999c8104a05f279b5bff2f473d9fL32-R33): Added `Title` field to the `Reference` struct and changed the type of `Content` from `[]string` to `string`.

### Updates to `CaseConversionServiceImpl` methods:

* [`internal/domain/services/mappers/case_mapper.go`](diffhunk://#diff-f71bfa9de6b5fdd097deeb031f7c60506b958732a7925a5982c3a43a786a78d2R259): Updated `MessageToDTO` method to include the `Title` field in the conversion.
* [`internal/domain/services/mappers/case_mapper.go`](diffhunk://#diff-f71bfa9de6b5fdd097deeb031f7c60506b958732a7925a5982c3a43a786a78d2R312): Updated `DTOToMessage` method to include the `Title` field in the conversion.

### Modifications to project structure:

* [`structure.MD`](diffhunk://#diff-3eac47b9028a90415bff010235b95db154d522c620c3d0007edcbb72404c6db3L11-R13): Updated the project structure to include new files `app.go`, `http_server.go`, and `main.go` under the `http` directory, replacing `server.go`.